### PR TITLE
radcli failover

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,11 +1,11 @@
-# 
+#
 #  $Id: configure.in,v 1.38 2008/03/05 18:02:55 cparker Exp $
-# 
+#
 #  Copyright (C) 1996,1997 Lars Fenneberg
-# 
-#  See the file COPYRIGHT for the respective terms and conditions. 
-# 
-# 
+#
+#  See the file COPYRIGHT for the respective terms and conditions.
+#
+#
 
 AC_INIT([radcli], [1.2.2], [n.mavrogiannopoulos@gmail.com])
 
@@ -65,9 +65,6 @@ AM_CONDITIONAL(ENABLE_LEGACY_COMPAT, test "$enable_compat" = "yes")
 
 dnl Check if we need -lsocket.
 AC_CHECK_LIB(socket, socket)
-
-dnl Checks for endianness
-AC_C_BIGENDIAN
 
 dnl Checks for header files.
 AC_HEADER_DIRENT
@@ -232,10 +229,6 @@ AC_ARG_ENABLE(scp,
 AC_SUBST(RC_SECURE_PATH)
 AC_SUBST(RC_LOG_FACILITY)
 
-AH_OUTPUT([BIG_ENDIAN], [/* is big endian arch ? */
-#undef BIG_ENDIAN])
-AH_OUTPUT([LITTLE_ENDIAN], [/* is little endian arch ? */
-#undef LITTLE_ENDIAN])
 AH_OUTPUT([HAVE_DEV_URANDOM], [/* does /dev/urandom exist ? */
 #undef HAVE_DEV_URANDOM])
 AH_OUTPUT([HAVE_SHADOW_PASSWORDS], [/* shadow password support */

--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,9 @@ AM_CONDITIONAL(ENABLE_LEGACY_COMPAT, test "$enable_compat" = "yes")
 dnl Check if we need -lsocket.
 AC_CHECK_LIB(socket, socket)
 
+dnl Checks for endianness
+AC_C_BIGENDIAN
+
 dnl Checks for header files.
 AC_HEADER_DIRENT
 AC_HEADER_STDC
@@ -107,7 +110,7 @@ then
 	AC_MSG_CHECKING([for field domainname in struct utsname])
 	AC_TRY_RUN([
 	#include <sys/utsname.h>
-	
+
 	main(int argc, char **argv)
 	{
 		struct utsname uts;

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -3,8 +3,8 @@
 #
 # Copyright (C) 1997,1998 Lars Fenneberg
 #
-# See the file COPYRIGHT for the respective terms and conditions. 
-# If the file is missing contact me at lf@elemental.net 
+# See the file COPYRIGHT for the respective terms and conditions.
+# If the file is missing contact me at lf@elemental.net
 # and I'll send you a copy.
 #
 
@@ -14,8 +14,10 @@ CLEANFILES = *~ radiusclient.conf radiusclient-tls.conf
 
 sbindir = @sbindir@
 pkgsysconfdir = @pkgsysconfdir@
-pkgsysconf_DATA = radiusclient.conf \
-	dictionary radiusclient-tls.conf
+pkgsysconf_DATA = radiusclient.conf radiusclient-tls.conf
+
+sharedir = $(datadir)/@PACKAGE@
+share_DATA = dictionary dictionary.microsoft dictionary.roaringpenguin
 
 EXTRA_DIST = dictionary servers servers-tls radiusclient.conf.in \
 	radiusclient-tls.conf.in

--- a/etc/dictionary
+++ b/etc/dictionary
@@ -303,6 +303,6 @@ VALUE		Add-Port-To-IP-Address	Yes			1
 #VALUE		Server-Config		Password-Expiration	30
 #VALUE		Server-Config		Password-Warning	5
 
-$INCLUDE /etc/ppp/radiusclient/dictionary.microsoft
-$INCLUDE /etc/ppp/radiusclient/dictionary.roaringpenguin
+$INCLUDE dictionary.microsoft
+$INCLUDE dictionary.roaringpenguin
 

--- a/etc/dictionary
+++ b/etc/dictionary
@@ -7,7 +7,9 @@
 #	is specified as one of 4 data types.  Valid data types are:
 #
 #	string - 0-253 octets
-#	ipaddr - 4 octets in network byte order
+#	ipv4addr- 4 octets in network byte order
+#	ipv6addr  - 16 octets in network byte order
+#	ipv6prefix- up to 16 octets in network byte order, plus prefix length
 #	integer - 32 bit value in big endian order (high byte first)
 #	date - 32 bit value in big endian order - seconds since
 #					00:00:00 GMT,  Jan.  1,  1970
@@ -29,24 +31,24 @@
 ATTRIBUTE	User-Name		1	string
 ATTRIBUTE	Password		2	string
 ATTRIBUTE	CHAP-Password		3	string
-ATTRIBUTE	NAS-IP-Address		4	ipaddr
+ATTRIBUTE	NAS-IP-Address		4	ipv4addr
 ATTRIBUTE	NAS-Port-Id		5	integer
 ATTRIBUTE	Service-Type		6	integer
 ATTRIBUTE	Framed-Protocol		7	integer
-ATTRIBUTE	Framed-IP-Address	8	ipaddr
-ATTRIBUTE	Framed-IP-Netmask	9	ipaddr
+ATTRIBUTE	Framed-IP-Address	8	ipv4addr
+ATTRIBUTE	Framed-IP-Netmask	9	ipv4addr
 ATTRIBUTE	Framed-Routing		10	integer
 ATTRIBUTE	Filter-Id		11	string
 ATTRIBUTE	Framed-MTU		12	integer
 ATTRIBUTE	Framed-Compression	13	integer
-ATTRIBUTE	Login-IP-Host		14	ipaddr
+ATTRIBUTE	Login-IP-Host		14	ipv4addr
 ATTRIBUTE	Login-Service		15	integer
 ATTRIBUTE	Login-TCP-Port		16	integer
 ATTRIBUTE	Reply-Message		18	string
 ATTRIBUTE	Callback-Number		19	string
 ATTRIBUTE	Callback-Id		20	string
 ATTRIBUTE	Framed-Route		22	string
-ATTRIBUTE	Framed-IPX-Network	23	ipaddr
+ATTRIBUTE	Framed-IPX-Network	23	ipv4addr
 ATTRIBUTE	State			24	string
 ATTRIBUTE	Class			25	string
 ATTRIBUTE	Vendor-Specific		26	string
@@ -132,6 +134,31 @@ ATTRIBUTE       Delegated-IPv6-Prefix   123     ipv6prefix
 ATTRIBUTE	Framed-IPv6-Address	168	ipv6addr
 ATTRIBUTE	DNS-Server-IPv6-Address	169	ipv6addr
 ATTRIBUTE	Route-IPv6-Information	170	ipv6prefix
+
+ATTRIBUTE	Huntgroup-Name		221	string
+#
+#	Non-Protocol Attributes
+#	These attributes are used internally by the server
+#
+ATTRIBUTE	Expiration		  21	date
+ATTRIBUTE	Auth-Type		1000	integer
+ATTRIBUTE	Menu			1001	string
+ATTRIBUTE	Termination-Menu	1002	string
+ATTRIBUTE	Prefix			1003	string
+ATTRIBUTE	Suffix			1004	string
+ATTRIBUTE	Group			1005	string
+ATTRIBUTE	Crypt-Password		1006	string
+ATTRIBUTE	Connect-Rate		1007	integer
+ATTRIBUTE	User-Category		1029	string
+ATTRIBUTE	Group-Name		1030	string
+ATTRIBUTE	Simultaneous-Use	1034	integer
+ATTRIBUTE	Strip-User-Name		1035	integer
+ATTRIBUTE	Fall-Through		1036	integer
+ATTRIBUTE	Add-Port-To-IP-Address	1037	integer
+ATTRIBUTE	Exec-Program		1038	string
+ATTRIBUTE	Exec-Program-Wait	1039	string
+ATTRIBUTE	Hint			1040	string
+
 
 #
 #	Integer Translations
@@ -275,4 +302,7 @@ VALUE		Add-Port-To-IP-Address	Yes			1
 
 #VALUE		Server-Config		Password-Expiration	30
 #VALUE		Server-Config		Password-Warning	5
+
+$INCLUDE /etc/ppp/radiusclient/dictionary.microsoft
+$INCLUDE /etc/ppp/radiusclient/dictionary.roaringpenguin
 

--- a/etc/dictionary.microsoft
+++ b/etc/dictionary.microsoft
@@ -1,0 +1,81 @@
+#
+#	Microsoft's VSA's, from RFC 2548
+#
+#	originally translated 2004/11/14 07:26:26 paulus
+#
+
+VENDOR		Microsoft	311	Microsoft
+
+ATTRIBUTE	MS-CHAP-Response	1	string	Microsoft
+ATTRIBUTE	MS-CHAP-Error		2	string	Microsoft
+ATTRIBUTE	MS-CHAP-CPW-1		3	string	Microsoft
+ATTRIBUTE	MS-CHAP-CPW-2		4	string	Microsoft
+ATTRIBUTE	MS-CHAP-LM-Enc-PW	5	string	Microsoft
+ATTRIBUTE	MS-CHAP-NT-Enc-PW	6	string	Microsoft
+ATTRIBUTE	MS-MPPE-Encryption-Policy 7	string	Microsoft
+# This is referred to as both singular and plural in the RFC.
+# Plural seems to make more sense.
+ATTRIBUTE	MS-MPPE-Encryption-Type 8	string	Microsoft
+ATTRIBUTE	MS-MPPE-Encryption-Types  8	string	Microsoft
+ATTRIBUTE	MS-RAS-Vendor		9	integer	Microsoft
+ATTRIBUTE	MS-CHAP-Domain		10	string	Microsoft
+ATTRIBUTE	MS-CHAP-Challenge	11	string	Microsoft
+ATTRIBUTE	MS-CHAP-MPPE-Keys	12	string	Microsoft
+ATTRIBUTE	MS-BAP-Usage		13	integer	Microsoft
+ATTRIBUTE	MS-Link-Utilization-Threshold 14 integer	Microsoft
+ATTRIBUTE	MS-Link-Drop-Time-Limit	15	integer	Microsoft
+ATTRIBUTE	MS-MPPE-Send-Key	16	string	Microsoft
+ATTRIBUTE	MS-MPPE-Recv-Key	17	string	Microsoft
+ATTRIBUTE	MS-RAS-Version		18	string	Microsoft
+ATTRIBUTE	MS-Old-ARAP-Password	19	string	Microsoft
+ATTRIBUTE	MS-New-ARAP-Password	20	string	Microsoft
+ATTRIBUTE	MS-ARAP-PW-Change-Reason 21	integer	Microsoft
+
+ATTRIBUTE	MS-Filter		22	string	Microsoft
+ATTRIBUTE	MS-Acct-Auth-Type	23	integer	Microsoft
+ATTRIBUTE	MS-Acct-EAP-Type	24	integer	Microsoft
+
+ATTRIBUTE	MS-CHAP2-Response	25	string	Microsoft
+ATTRIBUTE	MS-CHAP2-Success	26	string	Microsoft
+ATTRIBUTE	MS-CHAP2-CPW		27	string	Microsoft
+
+ATTRIBUTE	MS-Primary-DNS-Server	28	ipaddr	Microsoft
+ATTRIBUTE	MS-Secondary-DNS-Server	29	ipaddr	Microsoft
+ATTRIBUTE	MS-Primary-NBNS-Server	30	ipaddr	Microsoft
+ATTRIBUTE	MS-Secondary-NBNS-Server 31	ipaddr	Microsoft
+
+#ATTRIBUTE	MS-ARAP-Challenge	33	string	Microsoft
+
+
+#
+#	Integer Translations
+#
+
+#	MS-BAP-Usage Values
+
+VALUE		MS-BAP-Usage		Not-Allowed	0
+VALUE		MS-BAP-Usage		Allowed		1
+VALUE		MS-BAP-Usage		Required	2
+
+#	MS-ARAP-Password-Change-Reason Values
+
+VALUE	MS-ARAP-PW-Change-Reason	Just-Change-Password		1
+VALUE	MS-ARAP-PW-Change-Reason	Expired-Password		2
+VALUE	MS-ARAP-PW-Change-Reason	Admin-Requires-Password-Change	3
+VALUE	MS-ARAP-PW-Change-Reason	Password-Too-Short		4
+
+#	MS-Acct-Auth-Type Values
+
+VALUE		MS-Acct-Auth-Type	PAP		1
+VALUE		MS-Acct-Auth-Type	CHAP		2
+VALUE		MS-Acct-Auth-Type	MS-CHAP-1	3
+VALUE		MS-Acct-Auth-Type	MS-CHAP-2	4
+VALUE		MS-Acct-Auth-Type	EAP		5
+
+#	MS-Acct-EAP-Type Values
+
+VALUE		MS-Acct-EAP-Type	MD5		4
+VALUE		MS-Acct-EAP-Type	OTP		5
+VALUE		MS-Acct-EAP-Type	Generic-Token-Card	6
+VALUE		MS-Acct-EAP-Type	TLS		13
+

--- a/etc/dictionary.roaringpenguin
+++ b/etc/dictionary.roaringpenguin
@@ -1,0 +1,21 @@
+# Roaring Penguin Vendor-Specific Attributes
+
+# Our vendor ID from IANA
+VENDOR		RoaringPenguin	10055
+
+#
+# Roaring Penguin vendor-specific attributes
+#
+
+# Upstream speed limit in kb/s
+ATTRIBUTE	RP-Upstream-Speed-Limit		1	integer	RoaringPenguin
+
+# Downstream speed limit in kb/s
+ATTRIBUTE	RP-Downstream-Speed-Limit	2	integer	RoaringPenguin
+
+# Send a HURL
+ATTRIBUTE       RP-HURL                         3       string  RoaringPenguin
+
+# Send a MOTM
+ATTRIBUTE       RP-MOTM                         4       string  RoaringPenguin
+

--- a/include/includes.h
+++ b/include/includes.h
@@ -203,11 +203,12 @@ struct rc_conf
 	unsigned		so_type; /* rc_socket_type */
 };
 
-typedef struct rc_aaa_ctx_st
+/* older compilers don't like seeing this typedef along with the one in radcli.h */
+struct rc_aaa_ctx_st
 {
 	char	secret[MAX_SECRET_LENGTH + 1]; //!< The secret used for this request
 	uint8_t	request_vector[AUTH_VECTOR_LEN]; //< The auth vector used in this request
-} RC_AAA_CTX;
+};
 
 int rc_send_server_ctx (rc_handle *rh, RC_AAA_CTX **ctx, SEND_DATA *data,
                         char *msg, rc_type type);

--- a/include/radcli/radcli.h
+++ b/include/radcli/radcli.h
@@ -569,6 +569,7 @@ typedef struct rc_aaa_ctx_st RC_AAA_CTX;
   VALUE_PAIR *rc_avpair_gen(rc_handle const *rh, VALUE_PAIR *pair, unsigned char const *ptr,
 			  int length, int vendorpec);
 VALUE_PAIR *rc_avpair_get (VALUE_PAIR *vp, int attrid, int vendorpec);
+VALUE_PAIR *rc_avpair_copy(VALUE_PAIR *p);
 void rc_avpair_insert(VALUE_PAIR **a, VALUE_PAIR *p, VALUE_PAIR *b);
 void rc_avpair_free (VALUE_PAIR *pair);
 int rc_avpair_parse (rc_handle const *rh, char const *buffer, VALUE_PAIR **first_pair);

--- a/include/radcli/radcli.h
+++ b/include/radcli/radcli.h
@@ -45,7 +45,7 @@ extern "C" {
 
 /**
  * @defgroup radcli-api Main API
- * @brief Main API Functions 
+ * @brief Main API Functions
  *
  * @{
  */
@@ -536,7 +536,7 @@ typedef struct rc_aaa_ctx_st RC_AAA_CTX;
  *
  * Alternative operation without a configuration file is also possible, see
  * rc_add_config().
- * 
+ *
  * Check radexample.c for a functional example.
  *
  */

--- a/include/radcli/radcli.h
+++ b/include/radcli/radcli.h
@@ -391,7 +391,7 @@ typedef enum rc_acct_auth_type {
 /** \enum rc_vendor_pec --- http://www.iana.org/assignments/enterprise-numbers/enterprise-numbers
  */
 typedef enum rc_vendor_pec {
-  VENDOR_NONE=(-1),
+  VENDOR_NONE=0,
   VENDOR_MICROSOFT	     = 311,
   VENDOR_ROARING_PENGUIN     = 10055
 } rc_vendor_type;

--- a/include/radcli/radcli.h
+++ b/include/radcli/radcli.h
@@ -15,10 +15,12 @@
 #ifndef RADCLI_H
 #define RADCLI_H
 
+extern unsigned int radcli_debug;
+extern void rc_setdebug(int debug);
 #ifdef CP_DEBUG
-#define		DEBUG(args, ...)	rc_log(## args)
+#define		DEBUG(args...)	if(radcli_debug) syslog(args)
 #else
-#define		DEBUG(args, ...)	;
+#define		DEBUG(args...)	;
 #endif
 
 #include	<sys/types.h>

--- a/include/radcli/radcli.h
+++ b/include/radcli/radcli.h
@@ -388,6 +388,38 @@ typedef enum rc_acct_auth_type {
 	PW_REMOTE=3
 } rc_acct_auth_type;
 
+/** \enum rc_vendor_pec --- http://www.iana.org/assignments/enterprise-numbers/enterprise-numbers
+ */
+typedef enum rc_vendor_pec {
+  VENDOR_NONE=(-1),
+  VENDOR_MICROSOFT	     = 311,
+  VENDOR_ROARING_PENGUIN     = 10055
+} rc_vendor_type;
+
+/* Vendor RADIUS attribute-value pairs for MICROSOFT */
+enum rc_vendor_attr_microsoft {
+  PW_MS_CHAP_CHALLENGE	=	11,	/* string */
+  PW_MS_CHAP_RESPONSE	=	1,	/* string */
+  PW_MS_CHAP2_RESPONSE	=	25,	/* string */
+  PW_MS_CHAP2_SUCCESS	=	26,	/* string */
+  PW_MS_MPPE_ENCRYPTION_POLICY=	7,	/* string */
+  PW_MS_MPPE_ENCRYPTION_TYPE=	8,	/* string */
+  PW_MS_MPPE_ENCRYPTION_TYPES=PW_MS_MPPE_ENCRYPTION_TYPE,
+  PW_MS_CHAP_MPPE_KEYS	=	12,	/* string */
+  PW_MS_MPPE_SEND_KEY	=	16,	/* string */
+  PW_MS_MPPE_RECV_KEY	=	17,	/* string */
+  PW_MS_PRIMARY_DNS_SERVER=	28,	/* ipaddr */
+  PW_MS_SECONDARY_DNS_SERVER=	29,	/* ipaddr */
+  PW_MS_PRIMARY_NBNS_SERVER=	30,	/* ipaddr */
+  PW_MS_SECONDARY_NBNS_SERVER=	31,	/* ipaddr */
+};
+
+/* Vendor RADIUS attribute-value pairs for Roaring Penguin: Bandwidth bit rate limits */
+enum rc_vendor_attr_roaringpenguin {
+  PW_RP_UPSTREAM_LIMIT        =1,  /* integer */
+  PW_RP_DOWNSTREAM_LIMIT      =2,  /* integer */
+};
+
 /* PROHIBIT PROTOCOL */
 #define PW_DUMB			0	//!< 1 and 2 are defined in FRAMED PROTOCOLS.
 #define PW_AUTH_ONLY		3

--- a/include/radcli/radcli.h
+++ b/include/radcli/radcli.h
@@ -15,6 +15,7 @@
 #ifndef RADCLI_H
 #define RADCLI_H
 
+#undef CP_DEBUG
 extern unsigned int radcli_debug;
 extern void rc_setdebug(int debug);
 #ifdef CP_DEBUG

--- a/include/radcli/radcli.h
+++ b/include/radcli/radcli.h
@@ -87,7 +87,7 @@ typedef struct rc_conf rc_handle;
  * Several of its fields have been deprecated.
  */
 typedef struct server {
-	int max; //!< for backwards compatibility; its value will be 1.
+	int   max;
 	char *name[SERVER_MAX];
 	uint16_t port[SERVER_MAX];
 	char *secret[SERVER_MAX];

--- a/include/radcli/radcli.h
+++ b/include/radcli/radcli.h
@@ -563,10 +563,10 @@ typedef struct rc_aaa_ctx_st RC_AAA_CTX;
 
 /* avpair.c */
 
-VALUE_PAIR *rc_avpair_add (rc_handle const *rh, VALUE_PAIR **list, int attrid, void const *pval, int len, int vendorpec);
-int rc_avpair_assign (VALUE_PAIR *vp, void const *pval, int len);
-VALUE_PAIR *rc_avpair_new (rc_handle const *rh, int attrid, void const *pval, int len, int vendorpec);
-VALUE_PAIR *rc_avpair_gen(rc_handle const *rh, VALUE_PAIR *pair, unsigned char const *ptr,
+  VALUE_PAIR *rc_avpair_add (rc_handle const *rh, VALUE_PAIR **list, int attrid, void const *pval, int len, int vendorpec);
+  int rc_avpair_assign (VALUE_PAIR *vp, void const *pval, int len);
+  VALUE_PAIR *rc_avpair_new (rc_handle const *rh, int attrid, void const *pval, int len, int vendorpec);
+  VALUE_PAIR *rc_avpair_gen(rc_handle const *rh, VALUE_PAIR *pair, unsigned char const *ptr,
 			  int length, int vendorpec);
 VALUE_PAIR *rc_avpair_get (VALUE_PAIR *vp, int attrid, int vendorpec);
 void rc_avpair_insert(VALUE_PAIR **a, VALUE_PAIR *p, VALUE_PAIR *b);
@@ -585,7 +585,8 @@ void rc_avpair_get_attr (VALUE_PAIR *vp, unsigned *type, unsigned *id);
 
 void rc_buildreq(rc_handle const *rh, SEND_DATA *data, int code, char *server, unsigned short port,
 		 char *secret, int timeout, int retries);
-int rc_auth(rc_handle *rh, uint32_t client_port, VALUE_PAIR *send, VALUE_PAIR **received, char *msg);
+int rc_auth(rc_handle *rh, uint32_t client_port, VALUE_PAIR *send,
+            VALUE_PAIR **received, char *msg);
 int rc_auth_proxy(rc_handle *rh, VALUE_PAIR *send, VALUE_PAIR **received, char *msg);
 int rc_acct(rc_handle *rh, uint32_t client_port, VALUE_PAIR *send);
 int rc_acct_proxy(rc_handle *rh, VALUE_PAIR *send);

--- a/include/radcli/radcli.h
+++ b/include/radcli/radcli.h
@@ -595,8 +595,13 @@ int rc_check(rc_handle *rh, char *host, char *secret, unsigned short port, char 
 
 int rc_aaa(rc_handle *rh, uint32_t client_port, VALUE_PAIR *send, VALUE_PAIR **received,
 	   char *msg, int add_nas_port, rc_standard_codes request_type);
-int rc_aaa_ctx(rc_handle *rh, RC_AAA_CTX **ctx, uint32_t client_port, VALUE_PAIR *send, VALUE_PAIR **received,
-	        char *msg, int add_nas_port, rc_standard_codes request_type);
+int rc_aaa_ctx(rc_handle *rh, RC_AAA_CTX **ctx, uint32_t client_port, VALUE_PAIR *send,
+               VALUE_PAIR **received,
+               char *msg, int add_nas_port, rc_standard_codes request_type);
+int rc_aaa_ctx_server(rc_handle *rh, RC_AAA_CTX **ctx, SERVER *aaaserver,
+                      rc_type type, uint32_t client_port,
+                      VALUE_PAIR *send, VALUE_PAIR **received,
+                      char *msg, int add_nas_port, rc_standard_codes request_type);
 
 /* config.c */
 

--- a/include/radcli/radcli.h
+++ b/include/radcli/radcli.h
@@ -632,6 +632,9 @@ void rc_dict_free(rc_handle *rh);
 int rc_tls_fd(rc_handle * rh);
 int rc_check_tls(rc_handle * rh);
 
+/* util.c */
+char *rc_mksid __P((void));
+
 /* ip_util.c */
 
 unsigned short rc_getport(int type);

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -3,8 +3,8 @@
 #
 # Copyright (C) 1995,1997,1998 Lars Fenneberg
 #
-# See the file COPYRIGHT for the respective terms and conditions. 
-# If the file is missing contact me at lf@elemental.net 
+# See the file COPYRIGHT for the respective terms and conditions.
+# If the file is missing contact me at lf@elemental.net
 # and I'll send you a copy.
 #
 
@@ -23,6 +23,7 @@ CLEANFILES = *~
 # Pkg-config script.
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = radcli.pc
+sharedir = $(datadir)/@PACKAGE@
 DISTCLEANFILES = $(pkgconfig_DATA)
 
 lib_LTLIBRARIES =  libradcli.la

--- a/lib/avpair.c
+++ b/lib/avpair.c
@@ -1009,3 +1009,9 @@ void rc_avpair_get_attr (VALUE_PAIR *vp, unsigned *type, unsigned *id)
 }
 
 /** @} */
+/*
+ * Local Variables:
+ * c-basic-offset:8
+ * c-style: whitesmith
+ * End:
+ */

--- a/lib/avpair.c
+++ b/lib/avpair.c
@@ -152,12 +152,18 @@ VALUE_PAIR *rc_avpair_new (rc_handle const *rh, int attrid, void const *pval, in
 {
 	VALUE_PAIR     *vp = NULL;
 	DICT_ATTR      *pda;
+        int vattrid;
 
-	attrid = attrid | (vendorpec << 16);
-	if ((pda = rc_dict_getattr (rh, attrid)) == NULL)
+        if(vendorpec != VENDOR_NONE) {
+                vattrid = attrid | (vendorpec << 16);
+        } else {
+                vattrid = attrid;
+        }
+	if ((pda = rc_dict_getattr (rh, vattrid)) == NULL)
 	{
-		rc_log(LOG_ERR,"rc_avpair_new: no attribute %d in dictionary", attrid);
-		return NULL;
+                rc_log(LOG_ERR,"rc_avpair_new: no attribute %d/%u in dictionary",
+                       vendorpec,attrid);
+                return NULL;
 	}
 	if (vendorpec != 0 && rc_dict_getvend(rh, vendorpec) == NULL)
 	{
@@ -167,7 +173,7 @@ VALUE_PAIR *rc_avpair_new (rc_handle const *rh, int attrid, void const *pval, in
 	if ((vp = malloc (sizeof (VALUE_PAIR))) != NULL)
 	{
 		strlcpy (vp->name, pda->name, sizeof (vp->name));
-		vp->attribute = attrid;
+		vp->attribute = vattrid;
 		vp->next = NULL;
 		vp->type = pda->type;
 		if (rc_avpair_assign (vp, pval, len) == 0)

--- a/lib/avpair.c
+++ b/lib/avpair.c
@@ -24,7 +24,7 @@
 
 /**
  * @defgroup radcli-api Main API
- * @brief Main API Functions 
+ * @brief Main API Functions
  *
  * @{
  */

--- a/lib/avpair.c
+++ b/lib/avpair.c
@@ -394,6 +394,34 @@ VALUE_PAIR *rc_avpair_get (VALUE_PAIR *vp, int attrid, int vendorpec)
 	return vp;
 }
 
+/*
+ * Function: rc_avpair_copy
+ *
+ * Purpose: Return a copy of the existing list "p" ala strdup().
+ *
+ */
+VALUE_PAIR *rc_avpair_copy(VALUE_PAIR *p)
+{
+	VALUE_PAIR *vp, *fp = NULL, *lp = NULL;
+
+	while (p) {
+		vp = malloc(sizeof(VALUE_PAIR));
+		if (!vp) {
+                  rc_log(LOG_CRIT, "rc_avpair_copy: out of memory");
+                  return NULL;  /* could leak pairs already copied */
+		}
+		*vp = *p;
+		if (!fp)
+			fp = vp;
+		if (lp)
+			lp->next = vp;
+		lp = vp;
+		p = p->next;
+	}
+
+	return fp;
+}
+
 /** Insert a VALUE_PAIR into a list
  *
  * Given the address of an existing list "a" and a pointer to an entry "p" in that list, add the value pair "b" to

--- a/lib/buildreq.c
+++ b/lib/buildreq.c
@@ -188,8 +188,14 @@ int rc_aaa_ctx_server(rc_handle *rh, RC_AAA_CTX **ctx, SERVER *aaaserver,
             rc_avpair_free(data.receive_pairs);
           }
 
-          if(result == OK_RC) return result;
+          if(result == OK_RC) {
+            DEBUG(LOG_INFO,
+                  "servernum %u returned success", servernum);
+            return result;
+          }
 
+          //rc_log(LOG_ERR,
+          //       "servernum %u returned error: %d", servernum, result);
           servernum++;
         } while(servernum < aaaserver->max && result == TIMEOUT_RC);
 

--- a/lib/config.c
+++ b/lib/config.c
@@ -980,7 +980,6 @@ rc_socket_type rc_get_socket_type(rc_handle *rh)
 }
 
 /** @} */
-/*
  /*
  * Local Variables:
  * c-basic-offset:8

--- a/lib/config.c
+++ b/lib/config.c
@@ -980,3 +980,10 @@ rc_socket_type rc_get_socket_type(rc_handle *rh)
 }
 
 /** @} */
+/*
+ /*
+ * Local Variables:
+ * c-basic-offset:8
+ * c-style: whitesmith
+ * End:
+ */

--- a/lib/config.c
+++ b/lib/config.c
@@ -391,40 +391,41 @@ rc_handle *rc_config_init(rc_handle *rh)
 
 static int apply_config(rc_handle *rh)
 {
-	const char *txt;
-	int ret;
-
 	memset(&rh->own_bind_addr, 0, sizeof(rh->own_bind_addr));
 	rh->own_bind_addr_set = 0;
 	rc_own_bind_addr(rh, &rh->own_bind_addr);
 	rh->own_bind_addr_set = 1;
 #ifdef HAVE_GNUTLS
-	txt = rc_conf_str(rh, "serv-auth-type");
-	if (txt != NULL) {
-		if (strcasecmp(txt, "dtls") == 0) {
-		    	ret = rc_init_tls(rh, SEC_FLAG_DTLS);
-		} else if (strcasecmp(txt, "tls") == 0) {
-		    	ret = rc_init_tls(rh, 0);
-		} else {
-			rc_log(LOG_CRIT, "unknown server authentication type: %s", txt);
-			return -1;
-		}
+        {
+                const char *txt;
+                int ret;
+                txt = rc_conf_str(rh, "serv-auth-type");
+                if (txt != NULL) {
+                        if (strcasecmp(txt, "dtls") == 0) {
+                                ret = rc_init_tls(rh, SEC_FLAG_DTLS);
+                        } else if (strcasecmp(txt, "tls") == 0) {
+                                ret = rc_init_tls(rh, 0);
+                        } else {
+                                rc_log(LOG_CRIT, "unknown server authentication type: %s", txt);
+                                return -1;
+                        }
 
-	    	if (ret < 0) {
-	    		rc_log(LOG_CRIT, "error initializing %s", txt);
-			return -1;
-		}
-	}
+                        if (ret < 0) {
+                                rc_log(LOG_CRIT, "error initializing %s", txt);
+                                return -1;
+                        }
+                }
+        }
 #endif
 
-	return 0;	
+	return 0;
 
 }
 
 /** Read the global config file
  *
- * This function will load the provided configuration file, and 
- * any other files such as the dictionary. 
+ * This function will load the provided configuration file, and
+ * any other files such as the dictionary.
  *
  * Note: To preserve compatibility with libraries of the same API
  * which don't load the dictionary care is taken not to reload the

--- a/lib/dict.c
+++ b/lib/dict.c
@@ -127,6 +127,10 @@ int rc_read_dictionary (rc_handle *rh, char const *filename)
 			{
 				type = PW_TYPE_IPADDR;
 			}
+			else if (strcmp (typestr, "ipv4addr") == 0)
+			{
+				type = PW_TYPE_IPADDR;
+			}
 			else if (strcmp (typestr, "ipv6addr") == 0)
 			{
 				type = PW_TYPE_IPV6ADDR;

--- a/lib/dict.c
+++ b/lib/dict.c
@@ -14,7 +14,7 @@
 
 /**
  * @defgroup radcli-api Main API
- * @brief Main API Functions 
+ * @brief Main API Functions
  *
  * @{
  */

--- a/lib/log.c
+++ b/lib/log.c
@@ -11,6 +11,13 @@
 #include <includes.h>
 #include <radcli/radcli.h>
 
+unsigned int radcli_debug = 0;
+
+void rc_setdebug(int debug)
+{
+  radcli_debug = debug;
+}
+
 /**
  * @defgroup misc-api Miscellaneous API
  * @brief Miscellaneous functions

--- a/lib/options.h
+++ b/lib/options.h
@@ -45,6 +45,7 @@ static OPTION config_options_default[] = {
 {"radius_retries",	OT_INT,	ST_UNDEF, NULL},
 {"radius_deadtime",	OT_INT, ST_UNDEF, NULL},
 {"bindaddr",		OT_STR, ST_UNDEF, NULL},
+{"clientdebug",		OT_INT, ST_UNDEF, NULL},
 /* Deprecated options */
 {"login_radius",	OT_STR, ST_UNDEF, NULL},
 {"seqfile",		OT_STR, ST_UNDEF, NULL},

--- a/lib/radcli.map.in
+++ b/lib/radcli.map.in
@@ -55,6 +55,7 @@ RADCLI_@LIBMAJOR@
 	rc_get_srcaddr;
 	rc_openlog;
 	rc_send_server;
+        rc_setdebug;
 	rc_aaa_ctx_free;
 	rc_aaa_ctx_get_secret;
 	rc_aaa_ctx_get_vector;

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -485,8 +485,6 @@ int rc_send_server_ctx (rc_handle *rh, RC_AAA_CTX **ctx, SEND_DATA *data, char *
 	unsigned char   vector[AUTH_VECTOR_LEN];
 	uint8_t          recv_buffer[BUFFER_LEN];
 	uint8_t          send_buffer[BUFFER_LEN];
-	char		our_addr_txt[50] = ""; /* hold a text IP */
-	char		auth_addr_txt[50] = ""; /* hold a text IP */
 	uint8_t		*attr;
 	int		retries;
 	VALUE_PAIR 	*vp;
@@ -638,16 +636,21 @@ int rc_send_server_ctx (rc_handle *rh, RC_AAA_CTX **ctx, SEND_DATA *data, char *
 		auth->length = htons ((unsigned short) total_length);
 	}
 
-	getnameinfo(SA(&our_sockaddr), SS_LEN(&our_sockaddr), NULL, 0, our_addr_txt, sizeof(our_addr_txt), NI_NUMERICHOST);
-	getnameinfo(auth_addr->ai_addr, auth_addr->ai_addrlen, NULL, 0, auth_addr_txt, sizeof(auth_addr_txt), NI_NUMERICHOST);
+        if(radcli_debug) {
+          char		our_addr_txt[50] = ""; /* hold a text IP */
+          char		auth_addr_txt[50] = ""; /* hold a text IP */
 
-	DEBUG(LOG_ERR, "DEBUG: timeout=%d retries=%d local %s : 0, remote %s : %u\n",
-	      data->timeout, retry_max, our_addr_txt, auth_addr_txt, data->svc_port);
+          getnameinfo(SA(&our_sockaddr), SS_LEN(&our_sockaddr), NULL, 0, our_addr_txt, sizeof(our_addr_txt), NI_NUMERICHOST);
+          getnameinfo(auth_addr->ai_addr, auth_addr->ai_addrlen, NULL, 0, auth_addr_txt, sizeof(auth_addr_txt), NI_NUMERICHOST);
+
+          DEBUG(LOG_ERR, "DEBUG: timeout=%d retries=%d local %s : 0, remote %s : %u\n",
+                data->timeout, retry_max, our_addr_txt, auth_addr_txt, data->svc_port);
+        }
 
 	for (;;)
 	{
 		do {
-			result = sfuncs->sendto (sfuncs->ptr, sockfd, (char *) auth, (unsigned int)total_length, 
+			result = sfuncs->sendto (sfuncs->ptr, sockfd, (char *) auth, (unsigned int)total_length,
 				(int) 0, SA(auth_addr->ai_addr), auth_addr->ai_addrlen);
 		} while (result == -1 && errno == EINTR);
 		if (result == -1) {
@@ -725,13 +728,17 @@ int rc_send_server_ctx (rc_handle *rh, RC_AAA_CTX **ctx, SEND_DATA *data, char *
 		 */
 		if (retries++ >= retry_max)
 		{
-			rc_log(LOG_ERR,
-				"rc_send_server: no reply from RADIUS server %s:%u",
-				 auth_addr_txt, data->svc_port);
-			SCLOSE (sockfd);
-			memset (secret, '\0', sizeof (secret));
-			result = TIMEOUT_RC;
-			goto cleanup;
+                  char radius_server_ip[128];
+                  struct sockaddr_in *si = (struct sockaddr_in *)auth_addr->ai_addr;
+                  inet_ntop(auth_addr->ai_family, &si->sin_addr,
+                            radius_server_ip, sizeof(radius_server_ip));
+                  rc_log(LOG_ERR,
+                         "rc_send_server: no reply from RADIUS server %s:%u",
+                         radius_server_ip, data->svc_port);
+                  SCLOSE (sockfd);
+                  memset (secret, '\0', sizeof (secret));
+                  result = TIMEOUT_RC;
+                  goto cleanup;
 		}
 	}
 

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -490,6 +490,7 @@ int rc_send_server_ctx (rc_handle *rh, RC_AAA_CTX **ctx, SEND_DATA *data, char *
 	VALUE_PAIR 	*vp;
 	struct pollfd	pfd;
 	double		start_time, timeout;
+        char           *server_type = "auth";
 
 	server_name = data->server;
 	if (server_name == NULL || server_name[0] == '\0')
@@ -616,6 +617,7 @@ int rc_send_server_ctx (rc_handle *rh, RC_AAA_CTX **ctx, SEND_DATA *data, char *
 
 	if (data->code == PW_ACCOUNTING_REQUEST)
 	{
+                server_type = "acct";
 		total_length = rc_pack_list(data->send_pairs, secret, auth) + AUTH_HDR_LEN;
 
 		auth->length = htons ((unsigned short) total_length);
@@ -733,8 +735,8 @@ int rc_send_server_ctx (rc_handle *rh, RC_AAA_CTX **ctx, SEND_DATA *data, char *
                   inet_ntop(auth_addr->ai_family, &si->sin_addr,
                             radius_server_ip, sizeof(radius_server_ip));
                   rc_log(LOG_ERR,
-                         "rc_send_server: no reply from RADIUS server %s:%u",
-                         radius_server_ip, data->svc_port);
+                         "rc_send_server: no reply from RADIUS %s server %s:%u",
+                         server_type, radius_server_ip, data->svc_port);
                   SCLOSE (sockfd);
                   memset (secret, '\0', sizeof (secret));
                   result = TIMEOUT_RC;

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -641,8 +641,8 @@ int rc_send_server_ctx (rc_handle *rh, RC_AAA_CTX **ctx, SEND_DATA *data, char *
 	getnameinfo(SA(&our_sockaddr), SS_LEN(&our_sockaddr), NULL, 0, our_addr_txt, sizeof(our_addr_txt), NI_NUMERICHOST);
 	getnameinfo(auth_addr->ai_addr, auth_addr->ai_addrlen, NULL, 0, auth_addr_txt, sizeof(auth_addr_txt), NI_NUMERICHOST);
 
-	DEBUG(LOG_ERR, "DEBUG: local %s : 0, remote %s : %u\n", 
-	      our_addr_txt, auth_addr_txt, data->svc_port);
+	DEBUG(LOG_ERR, "DEBUG: timeout=%d retries=%d local %s : 0, remote %s : %u\n",
+	      data->timeout, retry_max, our_addr_txt, auth_addr_txt, data->svc_port);
 
 	for (;;)
 	{

--- a/lib/util.c
+++ b/lib/util.c
@@ -122,3 +122,24 @@ rc_strlcpy(char *dst, char const *src, size_t siz)
 
 #endif
 
+/*
+ * Function: rc_mksid
+ *
+ * Purpose: generate a quite unique string
+ *
+ * Remarks: not that unique at all...
+ *
+ */
+
+char *
+rc_mksid (void)
+{
+  static char buf[15];
+  static unsigned short int cnt = 0;
+  sprintf (buf, "%08lX%04X%02hX",
+	   (unsigned long int) time (NULL),
+	   (unsigned int) getpid (),
+	   cnt & 0xFF);
+  cnt++;
+  return buf;
+}

--- a/tests/failover-tests.sh
+++ b/tests/failover-tests.sh
@@ -18,7 +18,7 @@ if test -z "$SERVER_IP";then
 	exit 77
 fi
 
-sed 's/localhost/'$SERVER_IP'/g' <$srcdir/radiusclient.conf >radiusclient-temp.conf
+sed 's/localhost/127.1.1.1:9999,'$SERVER_IP'/g' <$srcdir/radiusclient.conf >radiusclient-temp.conf
 sed 's/localhost/'$SERVER_IP'/g' <$srcdir/servers >servers-temp
 
 ../src/radiusclient -D -i -f radiusclient-temp.conf  User-Name=test Password=test | tee $TMPFILE
@@ -62,7 +62,7 @@ if test $? != 0;then
 	exit 1
 fi
 
-rm -f servers-temp 
+rm -f servers-temp
 #cat $TMPFILE
 rm -f $TMPFILE
 rm -f radiusclient-temp.conf

--- a/tests/servers
+++ b/tests/servers
@@ -1,3 +1,6 @@
-## Server Name or Client/Server pair		Key		
+## Server Name or Client/Server pair		Key
 ## ----------------				---------------
 localhost/localhost				testing123
+
+# used by failover test as a broken target. not supposed to respond.
+127.1.1.1/127.1.1.1				testing123


### PR DESCRIPTION
This patch brings back the ability to failover from one server to another.
It also includes some missing bits to make it more compatible with the freeradius client of yesteryear.
The microsoft and roaring penguin libraries are included, but are moved from /etc to /usr/share.
(This matters for small embedded systems, as /usr is usually compressed, read-only, while /etc )

This could be broken up into multiple pull requests if desired.
(One issue that is unresolved is that the code needs to compile on older platforms where the automake isn't up to date, but that should be okay, as a tar.gz should be buildable with the right generated files, but that isn't working right yet)
